### PR TITLE
Cannot call .show on game.dice3d if Dice So Nice is not installed

### DIFF
--- a/module/helpers/roll.mjs
+++ b/module/helpers/roll.mjs
@@ -259,7 +259,7 @@ export async function createSuccessRollMessageData(rollCount, flavor, chatData, 
 
   text += '</ol></div></div>';
 
-  if (game.dice3d.show) {
+  if (game.dice3d?.show) {
     const data = {
       throws: [{
         dice: rolls.map(roll => ({
@@ -271,7 +271,7 @@ export async function createSuccessRollMessageData(rollCount, flavor, chatData, 
         }))
       }]
     }
-    await game.dice3d.show(data);
+    await game.dice3d?.show(data);
   }
 
   const result = successCount + modifier;


### PR DESCRIPTION
Hayo, just suggesting a change to add optional chaining to game.dice3d so .show is not called on null if Dice So Nice is not installed, which causes accuracy and damage rolling to do nothing.